### PR TITLE
Bump version to v0.9.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u111-jre-alpine
 LABEL maintainer "szyn"
 
-ENV DIGDAG_VERSION 0.9.12
+ENV DIGDAG_VERSION 0.9.13
 WORKDIR /src
 
 RUN apk add --no-cache \


### PR DESCRIPTION
See also [release note](https://github.com/treasure-data/digdag/blob/master/digdag-docs/src/releases/release-0.9.13.rs)