### PR TITLE
Bump version to 0.9.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u131-jre-alpine
 LABEL maintainer "szyn"
 
-ENV DIGDAG_VERSION 0.9.21
+ENV DIGDAG_VERSION 0.9.22
 WORKDIR /src
 
 RUN apk add --no-cache \


### PR DESCRIPTION
```console
$ docker run -it -p 65432:65432 --rm --name docker-digdag localhost/docker-digdag server -m -b 0.0.0.0
2018-01-23 11:36:00 +0000: Digdag v0.9.22
2018-01-23 11:36:03 +0000 [INFO] (main): secret encryption engine: disabled
2018-01-23 11:36:04 +0000 [INFO] (main): XNIO version 3.3.6.Final
2018-01-23 11:36:04 +0000 [INFO] (main): XNIO NIO Implementation Version 3.3.6.Final
2018-01-23 11:36:04 +0000 [INFO] (main): Starting server on 0.0.0.0:65432
2018-01-23 11:36:04 +0000 [INFO] (main): Bound on 0.0.0.0:65432 (api)
```
