### PR TITLE
Bump version openjdk 8u212

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u191-jre-alpine
+FROM openjdk:8u212-jre-alpine
 LABEL maintainer "szyn"
 
 ENV DIGDAG_VERSION 0.9.39


### PR DESCRIPTION
Since latest OpenJDK version is 8u212, How about update for that?
https://hub.docker.com/_/openjdk?tab=tags&page=1&name=jre-alpine
![image](https://user-images.githubusercontent.com/1734549/87160632-3bdc5a80-c2fe-11ea-999b-0559065d2c6e.png)
