### PR TITLE
Fix too many clients already

### DIFF
--- a/.docker/server.properties
+++ b/.docker/server.properties
@@ -11,3 +11,4 @@ database.user = digdag
 database.password = digdag
 database.host = postgres
 database.database = digdag_db
+database.maximumPoolSize = 32


### PR DESCRIPTION
Hi, syzm

I faced following logs when I run `docker-compose up`.

```
...
digdag_server_1  | 2020-10-29 11:57:40 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20151204221156
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160602123456
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160602184025
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160610154832
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160623123456
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160719172538
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160817123456
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160818043815
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160818220026
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160908175551
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160926123456
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20160928203753
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20161005225356
postgres_1       | 2020-10-29 11:57:41.314 UTC [169] FATAL:  sorry, too many clients already
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20161028112233
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20161110112233
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20161209001857
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20170116082921
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20170116090744
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20170223220127
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20190318175338
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: Applying database migration:20191105105927
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.core.database.DatabaseMigrator: 21 migrations applied.
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) org.xnio.Xnio: XNIO version 3.3.6.Final
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) org.xnio.nio.NioXnio: XNIO NIO Implementation Version 3.3.6.Final
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.guice.rs.server.undertow.UndertowServer: Starting server on 0.0.0.0:65432
digdag_server_1  | 2020-10-29 11:57:41 +0000 [INFO] (main) io.digdag.guice.rs.server.undertow.UndertowServer: Bound on 0.0.0.0:65432 (api)
postgres_1       | 2020-10-29 11:57:41.566 UTC [170] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:57:41.943 UTC [171] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:57:42.507 UTC [172] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:57:43.352 UTC [173] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:57:44.619 UTC [174] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:57:46.519 UTC [175] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:57:49.365 UTC [176] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:57:53.634 UTC [177] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:58:00.036 UTC [178] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:58:09.637 UTC [179] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:58:19.640 UTC [180] FATAL:  sorry, too many clients already
postgres_1       | 2020-10-29 11:58:29.643 UTC [181] FATAL:  sorry, too many clients already
...
```

Please see https://github.com/treasure-data/digdag/issues/478
In default, connections will be craeted depends on CPU core.

My laptop has 6 Core (12 threads) CPU. So I guess 384(32 * 6) connections were created.
I don't know to limit 32 connections is it appropriate or not, but no raise up.

Thank you.

